### PR TITLE
convert docker-machine-linode to APIv4 conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # docker-machine-linode
 
-Linode Driver Plugin for docker-machine.
-
-**Requires docker-machine version > v.0.5.0-rc1**
+Linode Driver Plugin for docker-machine. **Requires docker-machine version > v.0.5.0-rc1**
 
 # Install
 
@@ -12,16 +10,16 @@ First, docker-machine v0.5.0 rc2 is required, documentation for how to install `
 or you can install `docker-machine` from source code by running these commands
 
 ```bash
-$ go get github.com/docker/machine
-$ cd $GOPATH/src/github.com/docker/machine
-$ make build
+go get github.com/docker/machine
+cd $GOPATH/src/github.com/docker/machine
+make build
 ```
 
 Then, install `docker-machine-linode` driver in the $GOPATH and add $GOPATH/bin to the $PATH env. 
 
 ```bash
-go get github.com/taoh/docker-machine-linode
-cd $GOPATH/src/github.com/taoh/docker-machine-linode
+go get github.com/displague/docker-machine-linode
+cd $GOPATH/src/github.com/displague/docker-machine-linode
 make
 make install
 ```
@@ -29,6 +27,5 @@ make install
 # Run
 
 ```bash
-$ docker-machine create -d linode --linode-api-key=<linode-api-key> --linode-root-pass=<linode-root-pass> linode
+docker-machine create -d linode --linode-token=<linode-token> --linode-root-pass=<linode-root-pass> linode
 ```
-

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Linode Driver Plugin for docker-machine. **Requires docker-machine version > v.0.5.0-rc1**
 
-# Install
+## Install
 
 First, docker-machine v0.5.0 rc2 is required, documentation for how to install `docker-machine`
 [is available here](https://github.com/docker/machine/releases/tag/v0.5.0-rc2#Installation).
@@ -15,7 +15,7 @@ cd $GOPATH/src/github.com/docker/machine
 make build
 ```
 
-Then, install `docker-machine-linode` driver in the $GOPATH and add $GOPATH/bin to the $PATH env. 
+Then, install `docker-machine-linode` driver in the $GOPATH and add $GOPATH/bin to the $PATH env.
 
 ```bash
 go get github.com/displague/docker-machine-linode
@@ -24,8 +24,25 @@ make
 make install
 ```
 
-# Run
+## Run
+
+You will need a Linode APIv4 Personal Access Token.  Get one here: <https://developers.linode.com/api/v4#section/Personal-Access-Token>
 
 ```bash
 docker-machine create -d linode --linode-token=<linode-token> --linode-root-pass=<linode-root-pass> linode
 ```
+
+### Options
+
+| Argument | Env | Default | Description
+| --- | --- | --- | ---
+| linode-token | LINODE_TOKEN | None | *REQUIRED* Linode APIv4 Token (see <https://developers.linode.com/api/v4#section/Personal-Access-Token>)
+| linode-root-pass | LINODE_ROOT_PASSWORD | None | *REQUIRED* The Linode Instance `root_pass` (password assigned to the `root` account)
+| linode-label | LINODE_LABEL | **generated** | The Linode Instance `label`.  This `label` must be unique on the account.
+| linode-region | LINODE_REGION | `us-east` | The Linode Instance `region` (see <https://api.linode.com/v4/regions>)
+| linode-instance-type | LINODE_INSTANCE_TYPE | `g6-standard-4` | The Linode Instance `type` (see <https://api.linode.com/v4/linode/types>)
+| linode-image | LINODE_IMAGE | `linode/debian9` | The Linode Instance `image` which provides the Linux distribution (see <https://api.linode.com/v4/images>).
+| linode-kernel | LINODE_KERNEL | `linode/grub2` | The Linux Instance `kernel` to boot.  `linode/grub2` will defer to the distribution kernel. (see <https://api.linode.com/v4/linode/kernels> (`?page=N`))
+| linode-ssh-port | LINODE_SSH_PORT | `22` | The port that SSH is running on, needed for Docker Machine to provision the Linode.
+| linode-docker-port | LINODE_DOCKER_PORT | `2376` | The TCP port of the Linode that Docker will be listening on
+| linode-swap-size | LINODE_SWAP_SIZE | `512` | The amount of swap space provisioned on the Linode Instance

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker-machine create -d linode --linode-token=<linode-token> --linode-root-pass
 | linode-label | LINODE_LABEL | **generated** | The Linode Instance `label`.  This `label` must be unique on the account.
 | linode-region | LINODE_REGION | `us-east` | The Linode Instance `region` (see <https://api.linode.com/v4/regions>)
 | linode-instance-type | LINODE_INSTANCE_TYPE | `g6-standard-4` | The Linode Instance `type` (see <https://api.linode.com/v4/linode/types>)
-| linode-image | LINODE_IMAGE | `linode/debian9` | The Linode Instance `image` which provides the Linux distribution (see <https://api.linode.com/v4/images>).
+| linode-image | LINODE_IMAGE | `linode/ubuntu18.04` | The Linode Instance `image` which provides the Linux distribution (see <https://api.linode.com/v4/images>).
 | linode-kernel | LINODE_KERNEL | `linode/grub2` | The Linux Instance `kernel` to boot.  `linode/grub2` will defer to the distribution kernel. (see <https://api.linode.com/v4/linode/kernels> (`?page=N`))
 | linode-ssh-port | LINODE_SSH_PORT | `22` | The port that SSH is running on, needed for Docker Machine to provision the Linode.
 | linode-docker-port | LINODE_DOCKER_PORT | `2376` | The TCP port of the Linode that Docker will be listening on

--- a/bin/main.go
+++ b/bin/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	linode "github.com/displague/docker-machine-linode"
 	"github.com/docker/machine/libmachine/drivers/plugin"
-	linode "github.com/taoh/docker-machine-linode"
 )
 
 func main() {

--- a/linode.go
+++ b/linode.go
@@ -4,15 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"time"
+	"net"
 
+	"github.com/chiefy/linodego"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnflag"
-	"github.com/docker/machine/libmachine/mcnutils"
 	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
-	"github.com/taoh/linodego"
 )
 
 // Driver is the implementation of BaseDriver interface
@@ -20,20 +19,20 @@ type Driver struct {
 	*drivers.BaseDriver
 	client *linodego.Client
 
-	APIKey     string
+	APIToken   string
 	IPAddress  string
 	DockerPort int
 
-	LinodeId    int
-	LinodeLabel string
+	InstanceID    int
+	InstanceLabel string
 
-	DataCenterId   int
-	PlanId         int
-	PaymentTerm    int
+	Region         string
+	InstanceType   string
 	RootPassword   string
 	SSHPort        int
-	DistributionId int
-	KernelId       int
+	InstanceImage  string
+	InstanceKernel string
+	SwapSize       int
 }
 
 // NewDriver
@@ -49,7 +48,8 @@ func NewDriver(hostName, storePath string) *Driver {
 // Get Linode Client
 func (d *Driver) getClient() *linodego.Client {
 	if d.client == nil {
-		d.client = linodego.NewClient(d.APIKey, nil)
+		client := linodego.NewClient(&d.APIToken, nil)
+		d.client = &client
 	}
 	return d.client
 }
@@ -74,62 +74,62 @@ func (d *Driver) GetIP() (string, error) {
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.StringFlag{
-			Name:   "linode-api-key",
-			Usage:  "Linode API Key",
+			EnvVar: "LINODE_TOKEN",
+			Name:   "linode-api-token",
+			Usage:  "Linode API Token",
 			Value:  "",
-			EnvVar: "LINODE_API_KEY",
 		},
 		mcnflag.StringFlag{
 			EnvVar: "LINODE_ROOT_PASSWORD",
 			Name:   "linode-root-pass",
-			Usage:  "Root password",
+			Usage:  "Root Password",
 		},
 		mcnflag.StringFlag{
 			EnvVar: "LINODE_LABEL",
 			Name:   "linode-label",
-			Usage:  "Linode label",
+			Usage:  "Linode Instance Label",
 		},
-		mcnflag.IntFlag{
-			EnvVar: "LINODE_DATACENTER_ID",
-			Name:   "linode-datacenter-id",
-			Usage:  "Linode Data Center Id",
-			Value:  2,
+		mcnflag.StringFlag{
+			EnvVar: "LINODE_REGION",
+			Name:   "linode-region",
+			Usage:  "Linode Region",
+			Value:  "us-east", // "us-central", "ap-south", "eu-central", ...
 		},
-		mcnflag.IntFlag{
-			EnvVar: "LINODE_PLAN_ID",
-			Name:   "linode-plan-id",
-			Usage:  "Linode plan id",
-			Value:  1,
-		},
-		mcnflag.IntFlag{
-			EnvVar: "LINODE_PAYMENT_TERM",
-			Name:   "linode-payment-term",
-			Usage:  "Linode Payment term",
-			Value:  1, // valid values: 1, 12, 24
+		mcnflag.StringFlag{
+			EnvVar: "LINODE_INSTANCE_TYPE",
+			Name:   "linode-type",
+			Usage:  "Linode Instance Type",
+			Value:  "g6-standard-4", // "g6-nanode-1", g6-highmem-2, ...
 		},
 		mcnflag.IntFlag{
 			EnvVar: "LINODE_SSH_PORT",
 			Name:   "linode-ssh-port",
-			Usage:  "Linode SSH Port",
+			Usage:  "Linode Instance SSH Port",
 			Value:  22,
 		},
-		mcnflag.IntFlag{
-			EnvVar: "LINODE_DISTRIBUTION_ID",
-			Name:   "linode-distribution-id",
-			Usage:  "Linode Distribution Id",
-			Value:  140, // Debian 8 (Ubuntu 16.04 LTD = 146)
+		mcnflag.StringFlag{
+			EnvVar: "LINODE_IMAGE",
+			Name:   "linode-image",
+			Usage:  "Linode Instance Image",
+			Value:  "linode/debian8", // "linode/ubuntu18.04", "linode/arch", ...
 		},
-		mcnflag.IntFlag{
-			EnvVar: "LINODE_KERNEL_ID",
-			Name:   "linode-kernel-id",
-			Usage:  "Linode Kernel Id",
-			Value:  210, // default kernel, GRUB 2,
+		mcnflag.StringFlag{
+			EnvVar: "LINODE_KERNEL",
+			Name:   "linode-kernel",
+			Usage:  "Linode Instance Kernel",
+			Value:  "linode/grub2", // linode/latest-64bit, ..
 		},
 		mcnflag.IntFlag{
 			EnvVar: "LINODE_DOCKER_PORT",
 			Name:   "linode-docker-port",
 			Usage:  "Docker Port",
 			Value:  2376,
+		},
+		mcnflag.IntFlag{
+			EnvVar: "LINODE_SWAP_SIZE",
+			Name:   "linode-swap-size",
+			Usage:  "Linode Instance Swap Size (MB)",
+			Value:  512,
 		},
 	}
 }
@@ -143,19 +143,19 @@ func (d *Driver) GetSSHUsername() string {
 }
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
-	d.APIKey = flags.String("linode-api-key")
-	d.DataCenterId = flags.Int("linode-datacenter-id")
-	d.PlanId = flags.Int("linode-plan-id")
-	d.PaymentTerm = flags.Int("linode-payment-term")
+	d.APIToken = flags.String("linode-token")
+	d.Region = flags.String("linode-region")
+	d.InstanceType = flags.String("linode-type")
 	d.RootPassword = flags.String("linode-root-pass")
 	d.SSHPort = flags.Int("linode-ssh-port")
-	d.DistributionId = flags.Int("linode-distribution-id")
-	d.KernelId = flags.Int("linode-kernel-id")
-	d.LinodeLabel = flags.String("linode-label")
+	d.InstanceImage = flags.String("linode-image")
+	d.InstanceKernel = flags.String("linode-kernel")
+	d.InstanceLabel = flags.String("linode-label")
+	d.SwapSize = flags.Int("linode-swap-size")
 	d.DockerPort = flags.Int("linode-docker-port")
 
-	if d.APIKey == "" {
-		return fmt.Errorf("linode driver requires the --linode-api-key option")
+	if d.APIToken == "" {
+		return fmt.Errorf("linode driver requires the --linode-token option")
 	}
 
 	if d.RootPassword == "" {
@@ -181,116 +181,42 @@ func (d *Driver) Create() error {
 
 	// Create a linode
 	log.Debug("Creating linode instance")
-	linodeResponse, err := client.Linode.Create(
-		d.DataCenterId,
-		d.PlanId,
-		d.PaymentTerm,
-	)
+	createOpts := linodego.InstanceCreateOptions{
+		Region:         d.Region,
+		Type:           d.InstanceType,
+		Label:          d.InstanceLabel,
+		RootPass:       d.RootPassword,
+		AuthorizedKeys: []string{publicKey},
+		Image:          d.InstanceImage,
+		SwapSize:       &d.SwapSize,
+	}
+
+	linode, err := client.CreateInstance(&createOpts)
 	if err != nil {
 		return err
 	}
 
-	d.LinodeId = linodeResponse.LinodeId.LinodeId
-	log.Debugf("Linode created: %d", d.LinodeId)
-
-	if d.LinodeLabel != "" {
-		log.Debugf("Updating linode label to %s", d.LinodeLabel)
-		_, err := client.Linode.Update(d.LinodeId, map[string]interface{}{"Label": d.LinodeLabel})
-		if err != nil {
-			return err
-		}
-	}
-
-	linodeIPListResponse, err := client.Ip.List(d.LinodeId, -1)
-	if err != nil {
-		return err
-	}
-	for _, fullIpAddress := range linodeIPListResponse.FullIPAddresses {
-		if fullIpAddress.IsPublic == 1 {
-			d.IPAddress = fullIpAddress.IPAddress
+	for _, address := range linode.IPv4 {
+		if private := privateIP(*address); !private {
+			d.IPAddress = address.String()
+			break
 		}
 	}
 
 	if d.IPAddress == "" {
-		return errors.New("Linode IP Address is not found.")
+		return errors.New("Linode IP Address is not found")
 	}
 
-	log.Debugf("Created linode ID %d, IP address %s",
-		d.LinodeId,
+	log.Debugf("Created Linode Instance ID %d, IP address %s",
+		d.InstanceID,
 		d.IPAddress)
 
-	// Deploy distribution
-	args := make(map[string]string)
-	args["rootPass"] = d.RootPassword
-	args["rootSSHKey"] = publicKey
-	distributionId := d.DistributionId
-
-	log.Debug("Create disk")
-	createDiskJobResponse, err := d.client.Disk.CreateFromDistribution(distributionId, d.LinodeId, "Primary Disk", 20480-256, args)
-
-	if err != nil {
-		return err
-	}
-
-	jobId := createDiskJobResponse.DiskJob.JobId
-	diskId := createDiskJobResponse.DiskJob.DiskId
-	log.Debugf("Linode create disk task :%d.", jobId)
-
-	// wait until the creation is finished
-	err = d.waitForJob(jobId, "Create Disk Task", 60)
-	if err != nil {
-		return err
-	}
-
-	// create swap
-	log.Debug("Create swap disk")
-	createDiskJobResponse, err = d.client.Disk.Create(d.LinodeId, "swap", "Swap Disk", 256, nil)
-	if err != nil {
-		return err
-	}
-
-	jobId = createDiskJobResponse.DiskJob.JobId
-	swapDiskId := createDiskJobResponse.DiskJob.DiskId
-	log.Debugf("Linode create swap disk task :%d.", jobId)
-
-	// wait until the creation is finished
-	err = d.waitForJob(jobId, "Create Swap Disk Task", 60)
-	if err != nil {
-		return err
-	}
-
-	// create config
-	log.Debug("Create configuration")
-	args2 := make(map[string]string)
-	args2["DiskList"] = fmt.Sprintf("%d,%d", diskId, swapDiskId)
-	args2["RootDeviceNum"] = "1"
-	args2["RootDeviceRO"] = "true"
-	args2["helper_distro"] = "true"
-	kernelId := d.KernelId
-	_, err = d.client.Config.Create(d.LinodeId, kernelId, "My Docker Machine Configuration", args2)
-
-	if err != nil {
-		return err
-	}
-
-	log.Debugf("Linode configuration created.")
-
-	// Boot
-	log.Debug("Booting")
-	jobResponse, err := d.client.Linode.Boot(d.LinodeId, -1)
-	if err != nil {
-		return err
-	}
-	jobId = jobResponse.JobId.JobId
-	log.Debugf("Booting linode, job id: %v", jobId)
-	// wait for boot
-	err = d.waitForJob(jobId, "Booting linode", 60)
 	if err != nil {
 		return err
 	}
 
 	log.Debug("Waiting for Machine Running...")
-	if err := mcnutils.WaitForSpecific(drivers.MachineInState(d, state.Running), 120, 3*time.Second); err != nil {
+	if err := linodego.WaitForInstanceStatus(client, d.InstanceID, linodego.InstanceRunning, 120); err != nil {
 		return fmt.Errorf("wait for machine running failed: %s", err)
 	}
 
@@ -310,49 +236,49 @@ func (d *Driver) GetURL() (string, error) {
 }
 
 func (d *Driver) GetState() (state.State, error) {
-	linodes, err := d.getClient().Linode.List(d.LinodeId)
+	linode, err := d.getClient().GetInstance(d.InstanceID)
 	if err != nil {
 		return state.Error, err
 	}
 
-	// Status flag values:
-	// -2: Boot Failed
-	// -1: Being Created
-	//  0: Brand New
-	//  1: Running
-	//  2: Powered Off
-	//  3: Shutting Down
-	//  4: Saved to Disk
-	//
-	switch linodes.Linodes[0].Status {
-	case -1, 0:
-		return state.Starting, nil
-	case 1:
+	switch linode.Status {
+	case linodego.InstanceRunning:
 		return state.Running, nil
-	case -2, 2, 4:
+	case linodego.InstanceOffline,
+		linodego.InstanceRebuilding,
+		linodego.InstanceMigrating:
 		return state.Stopped, nil
-	case 3:
+	case linodego.InstanceShuttingDown, linodego.InstanceDeleting:
 		return state.Stopping, nil
+	case linodego.InstanceProvisioning,
+		linodego.InstanceRebooting,
+		linodego.InstanceBooting,
+		linodego.InstanceCloning,
+		linodego.InstanceRestoring:
+		return state.Starting, nil
+
 	}
+
+	// deleting, migrating, rebuilding, cloning, restoring ...
 	return state.None, nil
 }
 
 func (d *Driver) Start() error {
 	log.Debug("Start...")
-	_, err := d.getClient().Linode.Boot(d.LinodeId, -1)
+	_, err := d.getClient().BootInstance(d.InstanceID, 0)
 	return err
 }
 
 func (d *Driver) Stop() error {
 	log.Debug("Stop...")
-	_, err := d.getClient().Linode.Shutdown(d.LinodeId)
+	_, err := d.getClient().ShutdownInstance(d.InstanceID)
 	return err
 }
 
 func (d *Driver) Remove() error {
 	client := d.getClient()
-	log.Debugf("Removing linode: %d", d.LinodeId)
-	if _, err := client.Linode.Delete(d.LinodeId, true); err != nil {
+	log.Debugf("Removing linode: %d", d.InstanceID)
+	if err := client.DeleteInstance(d.InstanceID); err != nil {
 		return err
 	}
 	return nil
@@ -360,13 +286,13 @@ func (d *Driver) Remove() error {
 
 func (d *Driver) Restart() error {
 	log.Debug("Restarting...")
-	_, err := d.getClient().Linode.Reboot(d.LinodeId, -1)
+	_, err := d.getClient().RebootInstance(d.InstanceID)
 	return err
 }
 
 func (d *Driver) Kill() error {
 	log.Debug("Killing...")
-	_, err := d.getClient().Linode.Shutdown(d.LinodeId)
+	_, err := d.getClient().ShutdownInstance(d.InstanceID)
 	return err
 }
 
@@ -383,37 +309,18 @@ func (d *Driver) createSSHKey() (string, error) {
 	return string(publicKey), nil
 }
 
-// waitForJob checks job status every 1 second until timeout
-func (d *Driver) waitForJob(jobId int, jobName string, timeOutSeconds int) error {
-	log.Debugf("Wait for job %s completion...", jobName)
-	timeout := time.After(time.Duration(timeOutSeconds) * time.Second)
-	tick := time.Tick(1000 * time.Millisecond)
-	for {
-		select {
-		case <-timeout:
-			return fmt.Errorf("Job %s timed out after %d seconds.", jobName, timeOutSeconds)
-		case <-tick:
-			{
-				clientJobResponse, err := d.getClient().Job.List(d.LinodeId, jobId, false)
-				if err != nil {
-					return err
-				}
-
-				if len(clientJobResponse.Jobs) < 0 || clientJobResponse.Jobs[0].JobId != jobId {
-					return fmt.Errorf("Job %s is not found.", jobName)
-				}
-
-				if clientJobResponse.Jobs[0].HostSuccess.String() == "1" {
-					log.Debugf("Linode job %s completed.", jobName)
-					return nil
-				}
-				// if not success, wait for next check
-			}
-		}
-	}
-}
-
 // publicSSHKeyPath is always SSH Key Path appended with ".pub"
 func (d *Driver) publicSSHKeyPath() string {
 	return d.GetSSHKeyPath() + ".pub"
+}
+
+// privateIP determines if an IP is for private use (RFC1918)
+// https://stackoverflow.com/a/41273687
+func privateIP(ip net.IP) bool {
+	private := false
+	_, private24BitBlock, _ := net.ParseCIDR("10.0.0.0/8")
+	_, private20BitBlock, _ := net.ParseCIDR("172.16.0.0/12")
+	_, private16BitBlock, _ := net.ParseCIDR("192.168.0.0/16")
+	private = private24BitBlock.Contains(ip) || private20BitBlock.Contains(ip) || private16BitBlock.Contains(ip)
+	return private
 }

--- a/linode.go
+++ b/linode.go
@@ -41,7 +41,7 @@ type Driver struct {
 const (
 	defaultSSHPort        = 22
 	defaultSSHUser        = "root"
-	defaultInstanceImage  = "linode/debian9"
+	defaultInstanceImage  = "linode/ubuntu18.04"
 	defaultRegion         = "us-east"
 	defaultInstanceType   = "g6-standard-4"
 	defaultInstanceKernel = "linode/grub2"


### PR DESCRIPTION
Uses `chiefy/linodego` to access APIv4 endpoints (built locally against https://github.com/chiefy/linodego/pull/18 ).

Changes:
- `LINODE_API_KEY` must now be `LINODE_TOKEN` (not compatible - see https://developers.linode.com/api/v4#section/Personal-Access-Token)
- `LINODE_DATACENTER_ID` must now be `LINODE_REGION` ([listed here](https://api.linode.com/v4/regions))
- `LINODE_DISTRIBUTION_ID` must now be `LINODE_IMAGE` ([listed here](https://api.linode.com/v4/images))
- `LINODE_PLAN_ID` must now be `LINODE_INSTANCE_TYPE` ([listed here](https://api.linode.com/v4/linode/types))
- `LINODE_SWAP_SIZE` is now accepted (defaults to 512MB, the API default)
- `LINODE_PAYMENT_TERM` is no longer valid

I will want to add this driver to https://github.com/docker/docker.github.io/blob/master/machine/AVAILABLE_DRIVER_PLUGINS.md when working.


---
Referenced here https://github.com/taoh/docker-machine-linode/pull/11